### PR TITLE
fix: add opentelemetryBridgeEnabled option to TS declaration for AgentConfigOptions 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -276,6 +276,7 @@ declare namespace apm {
     maxQueueSize?: number;
     metricsInterval?: string; // Also support `number`, but as we're removing this functionality soon, there's no need to advertise it
     metricsLimit?: number;
+    opentelemetryBridgeEnabled?: boolean;
     payloadLogFile?: string;
     centralConfig?: boolean;
     sanitizeFieldNames?: Array<string>;


### PR DESCRIPTION
TypeScript declaration for `AgentConfigOptions` was missing the `opentelemetryBridgeEnabled` option.
